### PR TITLE
Bump dependencies to support spring boot 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
     <groupId>com.github.jwt.auth0</groupId>
     <artifactId>auth0-jwt-spring-boot</artifactId>
-        <version>3.1.1-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.0.RELEASE</version>
+        <version>2.0.0.RELEASE</version>
     </parent>
 
     <properties>
@@ -19,9 +19,9 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
 
-        <lombok.version>1.16.10</lombok.version>
+        <lombok.version>1.16.20</lombok.version>
         <jjwt.version>0.7.0</jjwt.version>
-        <jasypt.version>1.7</jasypt.version>
+        <jasypt.version>2.0.0</jasypt.version>
         <jsonpath.version>2.2.0</jsonpath.version>
         <commons-codec.version>1.4</commons-codec.version>
 


### PR DESCRIPTION
jasypt needs to be at version 2.0.0 to work with spring boot 2.